### PR TITLE
Drop Node 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "6"
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "loader.js": "^4.2.3"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "6.* || 8.* || >= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
... because Node 4 is no longer maintained by the Node.js team and several dependency updates are blocked because we still support Node 4.

This PR will require a new major version release.